### PR TITLE
Added support to keep app awake on Proxy Connect

### DIFF
--- a/RPC Builder/SmartDeviceLink/SDLManager.m
+++ b/RPC Builder/SmartDeviceLink/SDLManager.m
@@ -103,6 +103,7 @@ static NSString* const SDLRequestKey = @"request";
 }
 
 - (void)onProxyOpened {
+    [UIApplication sharedApplication].idleTimerDisabled = YES;
     if (self.registerAppDictionary) {
         [self sendRequestDictionary:self.registerAppDictionary
                            bulkData:nil];
@@ -128,6 +129,7 @@ static NSString* const SDLRequestKey = @"request";
 }
 
 - (void)sdl_stopProxy {
+    [UIApplication sharedApplication].idleTimerDisabled = NO;
     [_proxy dispose];
     _proxy = nil;
 }


### PR DESCRIPTION
Fixes #2

This PR is **ready** for review.
### Risk

This PR makes **no** API changes.
### Testing Plan

Open app and connect proxy. Wait until timeout timer to pass.
### Changelog
##### Enchancements
- When proxy connects, enable ability to keep app awake.
